### PR TITLE
Add kid in header

### DIFF
--- a/test/clj_jwt/core_test.clj
+++ b/test/clj_jwt/core_test.clj
@@ -94,7 +94,13 @@
       (-> token :claims :exp) => 946868645
       (-> token :claims :nbf) => 946782245
       (-> token :claims :iat) => 946782245
-      (-> token :claims :dmy) => d)))
+      (-> token :claims :dmy) => d))
+
+  (fact "signing with key-id, should include key-id in header."
+    (let [key-id "the-key-id"
+          signed-jwt (-> claim jwt (sign :RS256 key-id rsa-prv-key))]
+      (get-in signed-jwt [:header :kid])
+      => key-id)))
 
 (facts "JWT verify"
   (fact "Unknown signature algorithm should be thrown exception."

--- a/test/clj_jwt/core_test.clj
+++ b/test/clj_jwt/core_test.clj
@@ -100,7 +100,16 @@
     (let [key-id "the-key-id"
           signed-jwt (-> claim jwt (sign :RS256 key-id rsa-prv-key))]
       (get-in signed-jwt [:header :kid])
-      => key-id)))
+      => key-id))
+
+  (fact "signing without including a key-id does not include the `kid` key in the header."
+    (-> claim
+        jwt
+        (sign :RS256 rsa-prv-key)
+        :header
+        (contains? :kid))
+    =>
+    false))
 
 (facts "JWT verify"
   (fact "Unknown signature algorithm should be thrown exception."


### PR DESCRIPTION
In order to fully support the JSON Web Key Set standard, a JWT should be able to have a so called `kid` (key-id) field in the header.

This `kid` indicates what key-pair from the JSON Web Key Set was used to sign the JWT claims. This way it is possible for clients to automatically retrieve the public key to verify the claims in the JWT.

This PR adds functionality to indicate what value should be set for the `kid`. By default the `kid` key is not added to the header of the JWT.